### PR TITLE
decouple tgw vpc attachments from only public subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,87 @@
-# Tiered VPC-NG Description
-Baseline Tiered VPC-NG features (same as prototype):
+# Tiered VPC-NG
+`v1.0.1`
+- Private subnets now have a `special` attribute option like the public subnets.
+  - Now AZs can have private subnets only, public subnets only or both!
+  - Only 1 subnet, private or public can have `special = true` for VPC attachments per AZ when passed to Centralized Router `v1.0.1`.
+  - Private route tables are built per AZ
 
+- Public subnets now have a `natgw` attribute insted of having `enable_natgw`.
+  - Tag any public subnet with `natgw = true` to build the NATGW for all private subnets within the same AZ.
+  - `special` and `natgw` attributes can also be enabled together on a public subnet
+  - Only one public route table is built and shared across all public subnets in the VPC.
+
+- IGW now auto toggles if any public subnets are defined.
+- Set required `aws` provider version to >=5.31 and Terraform version >=1.4
+- Update deprecated `aws_eip` attribute
+- Not ideal to migrate to `v1.0.1` since there are many resource naming changes.
+  - Didnt have time figure out a move block migration.
+  - Recommend starting fresh at `v1.0.1`
+
+`v1.0.1` example:
+```
+locals {
+  tiered_vpcs = [
+    {
+      name         = "app"
+      network_cidr = "10.0.0.0/20"
+      azs = {
+        a = {
+          public_subnets = [
+            { name = "random1", cidr = "10.0.3.0/28" },
+            { name = "haproxy1", cidr = "10.0.4.0/26" },
+            { name = "other", cidr = "10.0.10.0/28", special = true }
+          ]
+        }
+        b = {
+          private_subnets = [
+            { name = "cluster2", cidr = "10.0.1.0/24" },
+            { name = "random2", cidr = "10.0.5.0/24", special = true }
+          ]
+        }
+      }
+    },
+    {
+      name         = "cicd"
+      network_cidr = "172.16.0.0/20"
+      azs = {
+        b = {
+          private_subnets = [
+            { name = "jenkins1", cidr = "172.16.5.0/24" }
+          ]
+          public_subnets = [
+            { name = "other", cidr = "172.16.8.0/28", special = true },
+            { name = "natgw", cidr = "172.16.8.16/28", natgw = true }
+          ]
+        }
+      }
+    },
+    {
+      name         = "general"
+      network_cidr = "192.168.0.0/20"
+      azs = {
+        c = {
+          private_subnets = [
+            { name = "db1", cidr = "192.168.10.0/24", special = true }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+module "vpcs" {
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.1"
+
+  for_each = { for t in local.tiered_vpcs : t.name => t }
+
+  env_prefix       = var.env_prefix
+  region_az_labels = var.region_az_labels
+  tiered_vpc       = each.value
+}
+```
+
+`v1.0.0`
 - Create VPC tiers
   - Thinking about VPCs as tiers helps narrow down the context (ie app, db, general) and maximize the use of smaller network size when needed.
   - You can still have 3 tiered networking (ie lbs, dbs for an app) internally to the VPC.
@@ -16,10 +97,10 @@ Baseline Tiered VPC-NG features (same as prototype):
 - Can access subnet id by subnet name map via output.
 - Can rename public and private subnets directly without forcing a new subnet resource.
 - Public subnets now have a special attribute option.
-  - Only one can have `special = true` which enables 3 things:
+  - Only one can have `special = true`
   - Associate a NAT Gateway if `enable_natgw = true`.
-  - Use for associating VPC attatchments when Tiered VPC is passed to a Centralized Router (one in each AZ).
-  - Existing public subnets can be rearranged in any order in their repective subnet list without forcing new resources.
+    - Use for associating VPC attatchments when Tiered VPC is passed to a Centralized Router (one in each AZ).
+     - Existing public subnets can be rearranged in any order in their repective subnet list without forcing new resources.
   - The trade off is always having to allocate one public subnet per AZ, even if you don’t need to use it (ie using private subnets only).
 - Important:
   - All VPC names should be unique across regions (validation enforced).
@@ -30,7 +111,7 @@ Baseline Tiered VPC-NG features (same as prototype):
   - all vpc names and network cidrs should be unique across regions
   - the routers will enforce uniqueness along with other validations
 
-Example:
+`v1.0.0` example:
 ```
 locals {
   tiered_vpcs = [
@@ -115,14 +196,14 @@ Main:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.31 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >=5.31 |
 
 ## Modules
 
@@ -135,8 +216,8 @@ No modules.
 | [aws_eip.this_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.this_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
-| [aws_route.public_route_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.this_private_route_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.this_public_route_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.this_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.this_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.this_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -155,7 +236,7 @@ No modules.
 | <a name="input_env_prefix"></a> [env\_prefix](#input\_env\_prefix) | prod, stage, test | `string` | n/a | yes |
 | <a name="input_region_az_labels"></a> [region\_az\_labels](#input\_region\_az\_labels) | Region and AZ names mapped to short naming conventions for labeling | `map(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional Tags | `map(string)` | `{}` | no |
-| <a name="input_tiered_vpc"></a> [tiered\_vpc](#input\_tiered\_vpc) | Tiered VPC configuration | <pre>object({<br>    name         = string<br>    network_cidr = string<br>    tenancy      = optional(string, "default")<br>    azs = map(object({<br>      enable_natgw = optional(bool, false)<br>      private_subnets = optional(list(object({<br>        name = string<br>        cidr = string<br>      })), [])<br>      public_subnets = list(object({<br>        name    = string<br>        cidr    = string<br>        special = optional(bool, false)<br>      }))<br>    }))<br>  })</pre> | n/a | yes |
+| <a name="input_tiered_vpc"></a> [tiered\_vpc](#input\_tiered\_vpc) | Tiered VPC configuration | <pre>object({<br>    name         = string<br>    network_cidr = string<br>    azs = map(object({<br>      private_subnets = optional(list(object({<br>        name    = string<br>        cidr    = string<br>        special = optional(bool, false)<br>      })), [])<br>      public_subnets = optional(list(object({<br>        name    = string<br>        cidr    = string<br>        special = optional(bool, false)<br>        natgw   = optional(bool, false)<br>      })), [])<br>    }))<br>    enable_dns_support   = optional(bool, true)<br>    enable_dns_hostnames = optional(bool, true)<br>  })</pre> | n/a | yes |
 
 ## Outputs
 
@@ -169,6 +250,7 @@ No modules.
 | <a name="output_name"></a> [name](#output\_name) | n/a |
 | <a name="output_network_cidr"></a> [network\_cidr](#output\_network\_cidr) | n/a |
 | <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | n/a |
+| <a name="output_private_special_subnet_ids"></a> [private\_special\_subnet\_ids](#output\_private\_special\_subnet\_ids) | n/a |
 | <a name="output_private_subnet_cidrs"></a> [private\_subnet\_cidrs](#output\_private\_subnet\_cidrs) | n/a |
 | <a name="output_private_subnet_name_to_subnet_id"></a> [private\_subnet\_name\_to\_subnet\_id](#output\_private\_subnet\_name\_to\_subnet\_id) | n/a |
 | <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | n/a |

--- a/base.tf
+++ b/base.tf
@@ -32,16 +32,21 @@ locals {
 
 resource "aws_vpc" "this" {
   cidr_block           = var.tiered_vpc.network_cidr
-  instance_tenancy     = var.tiered_vpc.tenancy
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+  enable_dns_support   = var.tiered_vpc.enable_dns_support
+  enable_dns_hostnames = var.tiered_vpc.enable_dns_hostnames
   tags = merge(
     local.default_tags,
     { Name = local.vpc_name }
   )
 }
 
+locals {
+  igw = { for this in [local.public_any_subnet_exists] : this => this if local.public_any_subnet_exists }
+}
+
 resource "aws_internet_gateway" "this" {
+  for_each = local.igw
+
   vpc_id = aws_vpc.this.id
   tags = merge(
     local.default_tags,

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,88 @@
 /*
-* # Tiered VPC-NG Description
-* Baseline Tiered VPC-NG features (same as prototype):
+* # Tiered VPC-NG
+* `v1.0.1`
+* - Private subnets now have a `special` attribute option like the public subnets.
+*   - Now AZs can have private subnets only, public subnets only or both!
+*   - Only 1 subnet, private or public can have `special = true` for VPC attachments per AZ when passed to Centralized Router `v1.0.1`.
+*   - Private route tables are built per AZ
 *
+* - Public subnets now have a `natgw` attribute insted of having `enable_natgw`.
+*   - Tag any public subnet with `natgw = true` to build the NATGW for all private subnets within the same AZ.
+*   - `special` and `natgw` attributes can also be enabled together on a public subnet
+*   - Only one public route table is built and shared across all public subnets in the VPC.
+*
+* - IGW now auto toggles if any public subnets are defined.
+* - Set required `aws` provider version to >=5.31 and Terraform version >=1.4
+* - Update deprecated `aws_eip` attribute
+* - Not ideal to migrate to `v1.0.1` since there are many resource naming changes.
+*   - Didnt have time figure out a move block migration.
+*   - Recommend starting fresh at `v1.0.1`
+*
+* `v1.0.1` example:
+* ```
+* locals {
+*   tiered_vpcs = [
+*     {
+*       name         = "app"
+*       network_cidr = "10.0.0.0/20"
+*       azs = {
+*         a = {
+*           public_subnets = [
+*             { name = "random1", cidr = "10.0.3.0/28" },
+*             { name = "haproxy1", cidr = "10.0.4.0/26" },
+*             { name = "other", cidr = "10.0.10.0/28", special = true }
+*           ]
+*         }
+*         b = {
+*           private_subnets = [
+*             { name = "cluster2", cidr = "10.0.1.0/24" },
+*             { name = "random2", cidr = "10.0.5.0/24", special = true }
+*           ]
+*         }
+*       }
+*     },
+*     {
+*       name         = "cicd"
+*       network_cidr = "172.16.0.0/20"
+*       azs = {
+*         b = {
+*           private_subnets = [
+*             { name = "jenkins1", cidr = "172.16.5.0/24" }
+*           ]
+*           public_subnets = [
+*             { name = "other", cidr = "172.16.8.0/28", special = true },
+*             { name = "natgw", cidr = "172.16.8.16/28", natgw = true }
+*           ]
+*         }
+*       }
+*     },
+*     {
+*       name         = "general"
+*       network_cidr = "192.168.0.0/20"
+*       azs = {
+*         c = {
+*           private_subnets = [
+*             { name = "db1", cidr = "192.168.10.0/24", special = true }
+*           ]
+*         }
+*       }
+*     }
+*   ]
+* }
+*
+* module "vpcs" {
+*   source  = "JudeQuintana/tiered-vpc-ng/aws"
+*   version = "1.0.1"
+*
+*   for_each = { for t in local.tiered_vpcs : t.name => t }
+*
+*   env_prefix       = var.env_prefix
+*   region_az_labels = var.region_az_labels
+*   tiered_vpc       = each.value
+* }
+* ```
+*
+* `v1.0.0`
 * - Create VPC tiers
 *   - Thinking about VPCs as tiers helps narrow down the context (ie app, db, general) and maximize the use of smaller network size when needed.
 *   - You can still have 3 tiered networking (ie lbs, dbs for an app) internally to the VPC.
@@ -17,10 +98,10 @@
 * - Can access subnet id by subnet name map via output.
 * - Can rename public and private subnets directly without forcing a new subnet resource.
 * - Public subnets now have a special attribute option.
-*   - Only one can have `special = true` which enables 3 things:
+*   - Only one can have `special = true`
 *   - Associate a NAT Gateway if `enable_natgw = true`.
-*   - Use for associating VPC attatchments when Tiered VPC is passed to a Centralized Router (one in each AZ).
-*   - Existing public subnets can be rearranged in any order in their repective subnet list without forcing new resources.
+*     - Use for associating VPC attatchments when Tiered VPC is passed to a Centralized Router (one in each AZ).
+*      - Existing public subnets can be rearranged in any order in their repective subnet list without forcing new resources.
 *   - The trade off is always having to allocate one public subnet per AZ, even if you don’t need to use it (ie using private subnets only).
 * - Important:
 *   - All VPC names should be unique across regions (validation enforced).
@@ -31,7 +112,7 @@
 *   - all vpc names and network cidrs should be unique across regions
 *   - the routers will enforce uniqueness along with other validations
 *
-* Example:
+* `v1.0.0` example:
 * ```
 * locals {
 *   tiered_vpcs = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,7 +32,7 @@ output "private_route_table_ids" {
 }
 
 output "private_subnet_cidrs" {
-  value = flatten([for this in var.tiered_vpc.azs : this.private_subnets[*].cidr])
+  value = local.private_subnet_cidrs
 }
 
 output "private_subnet_name_to_subnet_id" {
@@ -40,15 +40,19 @@ output "private_subnet_name_to_subnet_id" {
 }
 
 output "public_route_table_ids" {
-  value = [aws_route_table.this_public.id] # Each public subnet across AZs shares the same route table
+  value = [for this in aws_route_table.this_public : this.id] # Each public subnet across AZs shares the same route table
 }
 
 output "public_subnet_cidrs" {
-  value = flatten([for this in var.tiered_vpc.azs : this.public_subnets[*].cidr])
+  value = local.public_subnet_cidrs
 }
 
 output "public_special_subnet_ids" {
   value = [for this in local.public_az_to_special_subnet_cidr : lookup(aws_subnet.this_public, this).id]
+}
+
+output "private_special_subnet_ids" {
+  value = [for this in local.private_az_to_special_subnet_cidr : lookup(aws_subnet.this_private, this).id]
 }
 
 output "public_subnet_name_to_subnet_id" {

--- a/public.tf
+++ b/public.tf
@@ -1,12 +1,12 @@
 ############################################################################################################
 #
-# Public Subnets:
-# - It's required to have at least 1 public subnet with specail = true in a tiered vpc
-# - Public Route Table and Route for all subnets
-# - Route out IGW
+# - Public Subnets can have a special = true attribute set
+#   - for vpc attachment use when this module is passed to Centralized Router
+# - One Public Route Table shared by all public subnets
+# - IGW which now auto toggles based on if any public subnet exists
 #
 # If NATGWs are enabled for an AZ:
-# - NATGW is created in the public subnet with special = true for each AZ
+# - NATGW is created in the public subnet with natgw = true for each AZ
 # - EIP is created and associated to the NATGW
 #
 # Note:
@@ -17,16 +17,18 @@
 ############################################################################################################
 
 locals {
-  public_label                           = "public"
-  public_az_to_subnet_cidrs              = { for az, this in var.tiered_vpc.azs : az => this.public_subnets[*].cidr }
-  public_subnet_cidr_to_az               = { for subnet_cidr, azs in transpose(local.public_az_to_subnet_cidrs) : subnet_cidr => element(azs, 0) }
-  public_subnet_cidr_to_subnet_name      = merge([for this in var.tiered_vpc.azs : zipmap(this.public_subnets[*].cidr, this.public_subnets[*].name)]...)
-  public_az_to_special_subnet_cidr       = merge([for az, this in var.tiered_vpc.azs : { for public_subnet in this.public_subnets : az => public_subnet.cidr if public_subnet.special }]...)
-  public_natgw_az_to_special_subnet_cidr = { for az, this in var.tiered_vpc.azs : az => lookup(local.public_az_to_special_subnet_cidr, az) if this.enable_natgw }
+  public_label                      = "public"
+  public_subnet_cidrs               = toset(flatten([for this in var.tiered_vpc.azs : this.public_subnets[*].cidr]))
+  public_any_subnet_exists          = length(local.public_subnet_cidrs) > 0
+  public_az_to_subnet_cidrs         = { for az, this in var.tiered_vpc.azs : az => this.public_subnets[*].cidr if length(this.public_subnets[*].cidr) > 0 }
+  public_subnet_cidr_to_az          = { for subnet_cidr, azs in transpose(local.public_az_to_subnet_cidrs) : subnet_cidr => element(azs, 0) }
+  public_subnet_cidr_to_subnet_name = merge([for this in var.tiered_vpc.azs : zipmap(this.public_subnets[*].cidr, this.public_subnets[*].name)]...)
+  public_az_to_special_subnet_cidr  = merge([for az, this in var.tiered_vpc.azs : { for public_subnet in this.public_subnets : az => public_subnet.cidr if public_subnet.special }]...)
+  public_natgw_az_to_subnet_cidr    = merge([for az, this in var.tiered_vpc.azs : { for public_subnet in this.public_subnets : az => public_subnet.cidr if public_subnet.natgw }]...)
 }
 
 resource "aws_subnet" "this_public" {
-  for_each = local.public_subnet_cidr_to_subnet_name
+  for_each = local.public_subnet_cidrs
 
   vpc_id                  = aws_vpc.this.id
   availability_zone       = format("%s%s", local.region_name, lookup(local.public_subnet_cidr_to_az, each.key))
@@ -40,7 +42,7 @@ resource "aws_subnet" "this_public" {
         upper(var.env_prefix),
         var.tiered_vpc.name,
         local.public_label,
-        each.value,
+        lookup(local.public_subnet_cidr_to_subnet_name, each.key),
         lookup(var.region_az_labels, format("%s%s", local.region_name, lookup(local.public_subnet_cidr_to_az, each.key)))
       )
   })
@@ -48,6 +50,8 @@ resource "aws_subnet" "this_public" {
 
 # one public route table for all public subnets across azs
 resource "aws_route_table" "this_public" {
+  for_each = local.igw
+
   vpc_id = aws_vpc.this.id
   tags = merge(
     local.default_tags,
@@ -63,19 +67,22 @@ resource "aws_route_table" "this_public" {
   })
 }
 
-# one public route out through IGW for all public subnets across azs
-resource "aws_route" "public_route_out" {
+# one public route out through IGW for all public subnets across azs if an igw exists
+# igw will exists if public subnet exists
+resource "aws_route" "this_public_route_out" {
+  for_each = local.igw
+
   destination_cidr_block = local.route_any_cidr
-  route_table_id         = aws_route_table.this_public.id
-  gateway_id             = aws_internet_gateway.this.id
+  route_table_id         = lookup(aws_route_table.this_public, each.key).id
+  gateway_id             = lookup(aws_internet_gateway.this, each.key).id
 }
 
 # associate each public subnet to the shared route table
 resource "aws_route_table_association" "this_public" {
-  for_each = local.public_subnet_cidr_to_subnet_name
+  for_each = local.public_subnet_cidrs
 
   subnet_id      = lookup(aws_subnet.this_public, each.key).id
-  route_table_id = aws_route_table.this_public.id
+  route_table_id = lookup(aws_route_table.this_public, local.public_any_subnet_exists).id
 }
 
 #######################################################
@@ -87,9 +94,9 @@ resource "aws_route_table_association" "this_public" {
 
 # one eip per natgw (one per az)
 resource "aws_eip" "this_public" {
-  for_each = local.public_natgw_az_to_special_subnet_cidr
+  for_each = local.public_natgw_az_to_subnet_cidr
 
-  vpc = true
+  domain = "vpc"
   tags = merge(
     local.default_tags,
     {
@@ -116,7 +123,7 @@ resource "aws_eip" "this_public" {
 #######################################################
 
 resource "aws_nat_gateway" "this_public" {
-  for_each = local.public_natgw_az_to_special_subnet_cidr
+  for_each = local.public_natgw_az_to_subnet_cidr
 
   allocation_id = lookup(aws_eip.this_public, each.key).id
   subnet_id     = lookup(aws_subnet.this_public, each.value).id

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">=1.3"
+  required_version = ">=1.4" # using anytrue()
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20"
+      version = ">=5.31"
     }
   }
 }


### PR DESCRIPTION
- can tag either 1 private subnet or 1 public subnet per AZ for vpc_attachments (special = true) when passed to Centralized Router.
- can optionally tag 1 public subnet to host the natgw per AZ.
- auto toggle igw based on if there are any public subnets
- use cidrnetmask() for ipv4 cidr validation
- set aws provider versions to >=5.31
- update deprecated aws_eip attribute
- resource naming changes