### PR TITLE
logic clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Tiered VPC-NG
 
+`v1.0.6`
+- minor: public\_az\_to\_subnet\_cidrs and isolated\_az\_to\_subnet\_cidrs logic not needed but is required for private\_az\_to\_subnet\_cidrs because it is used for route table resource creation.
+
 `v1.0.5`
 - support for centralized egress modes when passed to centralized router
   - `central = true` makes VPC the egress VPC

--- a/base.tf
+++ b/base.tf
@@ -15,9 +15,6 @@ locals {
   route_any_cidr      = "0.0.0.0/0"
   route_any_ipv6_cidr = "::/0"
   upper_env_prefix    = upper(var.env_prefix)
-
-  # Set Environment tag since we have have var.env_prefix
-  # add or override with var.tags
   default_tags = merge({
     Environment = var.env_prefix
   }, var.tags)

--- a/isolated.tf
+++ b/isolated.tf
@@ -3,7 +3,7 @@ locals {
   isolated_subnet_cidrs               = toset(flatten([for az, this in var.tiered_vpc.azs : this.isolated_subnets[*].cidr]))
   isolated_any_subnet_exists          = length(local.isolated_subnet_cidrs) > 0
   isolated_route_table                = { for this in [local.isolated_any_subnet_exists] : this => this if local.isolated_any_subnet_exists }
-  isolated_az_to_subnet_cidrs         = { for az, this in var.tiered_vpc.azs : az => this.isolated_subnets[*].cidr if local.isolated_any_subnet_exists }
+  isolated_az_to_subnet_cidrs         = { for az, this in var.tiered_vpc.azs : az => this.isolated_subnets[*].cidr }
   isolated_subnet_cidr_to_az          = { for subnet_cidr, azs in transpose(local.isolated_az_to_subnet_cidrs) : subnet_cidr => element(azs, 0) }
   isolated_subnet_cidr_to_subnet_name = merge([for this in var.tiered_vpc.azs : zipmap(this.isolated_subnets[*].cidr, this.isolated_subnets[*].name)]...)
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 /*
 * # Tiered VPC-NG
 *
+* `v1.0.6`
+* - minor: public_az_to_subnet_cidrs and isolated_az_to_subnet_cidrs logic not needed but is required for private_az_to_subnet_cidrs because it is used for route table resource creation.
+*
 * `v1.0.5`
 * - support for centralized egress modes when passed to centralized router
 *   - `central = true` makes VPC the egress VPC

--- a/public.tf
+++ b/public.tf
@@ -2,7 +2,7 @@ locals {
   public_label                      = "public"
   public_subnet_cidrs               = toset(flatten([for this in var.tiered_vpc.azs : this.public_subnets[*].cidr]))
   public_any_subnet_exists          = length(local.public_subnet_cidrs) > 0
-  public_az_to_subnet_cidrs         = { for az, this in var.tiered_vpc.azs : az => this.public_subnets[*].cidr if length(this.public_subnets) > 0 }
+  public_az_to_subnet_cidrs         = { for az, this in var.tiered_vpc.azs : az => this.public_subnets[*].cidr }
   public_subnet_cidr_to_az          = { for subnet_cidr, azs in transpose(local.public_az_to_subnet_cidrs) : subnet_cidr => element(azs, 0) }
   public_subnet_cidr_to_subnet_name = merge([for this in var.tiered_vpc.azs : zipmap(this.public_subnets[*].cidr, this.public_subnets[*].name)]...)
   public_az_to_special_subnet_cidr  = merge([for az, this in var.tiered_vpc.azs : { for public_subnet in this.public_subnets : az => public_subnet.cidr if public_subnet.special }]...)


### PR DESCRIPTION
- minor: public\_az\_to\_subnet\_cidrs and isolated\_az\_to\_subnet\_cidrs logic not needed but is required for private\_az\_to\_subnet\_cidrs because it is used for route table resource creation.
